### PR TITLE
handle more default proto types

### DIFF
--- a/internal/converter/testdata/proto/WellKnown.proto
+++ b/internal/converter/testdata/proto/WellKnown.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package samples;
 import "google/protobuf/duration.proto";
+import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/wrappers.proto";
 
@@ -12,5 +13,6 @@ message WellKnown {
     // This is a duration:
     google.protobuf.Duration duration = 5;
     google.protobuf.Struct struct = 6;
+    google.protobuf.Empty empty = 7;
 }
 

--- a/internal/converter/testdata/wellknown.go
+++ b/internal/converter/testdata/wellknown.go
@@ -40,8 +40,12 @@ const WellKnown = `{
                     "format": "regex"
                 },
                 "struct": {
-                    "additionalProperties": true,
-                    "type": "object"
+                    "type": "object",
+                    "format": "struct"
+                },
+                "empty": {
+                    "type": "object",
+                    "format": "empty"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -259,6 +259,12 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		case ".google.protobuf.Timestamp":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 			jsonSchemaType.Format = "date-time"
+		case ".google.protobuf.Empty":
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			jsonSchemaType.Format = "empty"
+		case ".google.protobuf.Struct":
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			jsonSchemaType.Format = "struct"
 		default:
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
 			if desc.GetLabel() == descriptor.FieldDescriptorProto_LABEL_OPTIONAL {
@@ -548,8 +554,12 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 			}
 		case "Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+		case "Empty":
+			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			jsonSchemaType.Format = "empty"
 		case "Struct":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
+			jsonSchemaType.Format = "struct"
 		}
 
 		// If we're allowing nulls then prepare a OneOf:


### PR DESCRIPTION
special case for `google.protobuf.Empty` and `google.protobuf.Struct`
Previously, the generated json shows no differentiation between `google.protobuf.Empty` and `google.protobuf.Struct`, making it problematic in displaying types for [doc generation](https://docs.google.com/document/d/1-GcTITbbu4771SnjZz3GyTgD_V7u9uj169Je8dZN1HM/edit).
The solution is not perfect (struct and empty are not really "formats") but was a simple way to distinguish between the two.

modified/added tests to existing WellKnown test