### PR TITLE
Don't overwrite Options field in jsonschematype for enums

### DIFF
--- a/internal/converter/testdata/enum_reference.go
+++ b/internal/converter/testdata/enum_reference.go
@@ -15,6 +15,23 @@ const EnumReference1 = `{
                 "enumFieldTwo": {
                     "$ref": "#/definitions/samples.MessageWithEnums.NestedEnum",
                     "title": "Nested Enum"
+                },
+                "enum_with_manual": {
+                    "$ref": "#/definitions/samples.EnumOne",
+                    "options": {
+                        "manualLink": "manual-link-1"
+                    },
+                    "title": "Enum One"
+                },
+                "enum_with_manual_array": {
+                    "items": {
+                        "$ref": "#/definitions/samples.EnumOne",
+                        "title": "Enum One"
+                    },
+                    "type": "array",
+                    "options": {
+                        "manualLink": "manual-link-2"
+                    }
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/testdata/proto/EnumReference.proto
+++ b/internal/converter/testdata/proto/EnumReference.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package samples;
 
+import "options.proto";
+
 enum EnumOne {
     Foo = 0;
     Bar = 1;
@@ -11,6 +13,10 @@ message MessageWithEnums {
   // Comment about EnumOne.
   EnumOne enumFieldOne = 1;
   NestedEnum enumFieldTwo = 2;
+
+  EnumOne enum_with_manual = 3 [(protoc.gen.jsonschema.manual_link) = "manual-link-1"];
+  repeated EnumOne enum_with_manual_array = 4 [(protoc.gen.jsonschema.manual_link) = "manual-link-2"];
+
 
   enum NestedEnum {
     Foo = 0;

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -227,6 +227,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 	// ENUM:
 	case descriptor.FieldDescriptorProto_TYPE_ENUM:
 		fieldDescription := jsonSchemaType.Description
+		options := jsonSchemaType.Options
 
 		// Go through all the enums we have, see if we can match any to this field.
 		fullEnumIdentifier := strings.TrimPrefix(desc.GetTypeName(), ".")
@@ -247,6 +248,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 
 		jsonSchemaType = &enumSchema
 		jsonSchemaType.Description = fieldDescription
+		jsonSchemaType.Options = options
 		jsonSchemaType.Ref = fmt.Sprintf("%s%s", c.refPrefix, enums[matchedEnum])
 
 	// Bool:
@@ -302,7 +304,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 			// Set fields in jsonSchemaType.Items
 			jsonSchemaType.Items.Title = jsonSchemaType.Title
 			jsonSchemaType.Items.Ref = jsonSchemaType.Ref
-			
+
 			// Unset fields in jsonSchemaType
 			jsonSchemaType.Title = ""
 			jsonSchemaType.Enum = nil
@@ -482,7 +484,7 @@ func (c *Converter) convertMessageType(curPkg *ProtoPackage, msgDesc *descriptor
 	newJSONSchema := &jsonschema.Schema{
 		Type: &jsonschema.Type{
 			Ref:     fmt.Sprintf("%s%s", c.refPrefix, msgDesc.GetName()),
-			FullRef:     fmt.Sprintf("%s%s.%s", c.refPrefix, pkgName, msgDesc.GetName()),
+			FullRef: fmt.Sprintf("%s%s.%s", c.refPrefix, pkgName, msgDesc.GetName()),
 			Version: c.schemaVersion,
 		},
 		Definitions: definitions,


### PR DESCRIPTION
Specifically, jsonschemaType.Options.ManualLink was getting overwritten ☹️ 