### PR TITLE
Check for enums in unreferenced messages; remove enum values from references

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -212,14 +212,14 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:      "EnumReference.proto",
 		},
 		"EnumUnused": {
-			ExpectedJSONSchema:    []string{testdata.MessageUnusedEnum},
-			FilesToGenerate:       []string{"EnumUnused.proto"},
-			ProtoFileName:         "EnumUnused.proto",
+			ExpectedJSONSchema: []string{testdata.MessageUnusedEnum},
+			FilesToGenerate:    []string{"EnumUnused.proto"},
+			ProtoFileName:      "EnumUnused.proto",
 		},
 		"MessageUnused": {
-			ExpectedJSONSchema:    []string{testdata.MessageUnusedMessage},
-			FilesToGenerate:       []string{"MessageUnused.proto"},
-			ProtoFileName:         "MessageUnused.proto",
+			ExpectedJSONSchema: []string{testdata.MessageUnusedMessage},
+			FilesToGenerate:    []string{"MessageUnused.proto"},
+			ProtoFileName:      "MessageUnused.proto",
 		},
 		"EnumWithMessage": {
 			ExpectedJSONSchema:    []string{testdata.EnumWithMessageEnum, testdata.EnumWithMessage},
@@ -282,6 +282,11 @@ func configureSampleProtos() map[string]sampleProto {
 			ProtoFileName:         "NestedObject.proto",
 			ObjectsToValidateFail: []string{testdata.NestedObjectFail},
 			ObjectsToValidatePass: []string{testdata.NestedObjectPass},
+		},
+		"NestedUnreferencedEnum": {
+			ExpectedJSONSchema: []string{testdata.NestedUnreferencedEnum},
+			FilesToGenerate:    []string{"NestedUnreferencedEnum.proto"},
+			ProtoFileName:      "NestedUnreferencedEnum.proto",
 		},
 		"NoPackage": {
 			ExpectedJSONSchema: []string{},

--- a/internal/converter/testdata/nested_unreferenced_enum.go
+++ b/internal/converter/testdata/nested_unreferenced_enum.go
@@ -1,0 +1,67 @@
+package testdata
+
+const NestedUnreferencedEnum = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$ref": "#/definitions/Outfit",
+    "$fullRef": "#/definitions/samples.Outfit",
+    "definitions": {
+        "Outfit": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Outfit",
+            "description": "A set of predefined gear ratios and torque maps."
+        },
+        "samples.Outfit.Pants": {
+            "properties": {
+                "pants_type": {
+                    "$ref": "#/definitions/samples.Outfit.Pants.PantsType",
+                    "type": "string",
+                    "title": "Pants Type",
+                    "description": "When pants_type is unset, no pants are selected. Not recommended."
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Pants"
+        },
+        "samples.Outfit.Pants.PantsType": {
+            "enum": [
+                "SHORTS",
+                "LONG_PANTS"
+            ],
+            "enumValues": [
+                0,
+                1
+            ],
+            "type": "string",
+            "title": "Pants Type"
+        },
+        "samples.Outfit.Shirt": {
+            "properties": {
+                "shirt_type": {
+                    "$ref": "#/definitions/samples.Outfit.Shirt.ShirtType",
+                    "type": "string",
+                    "title": "Shirt Type",
+                    "description": "When shirt_type is unset, no shirt is selected."
+                }
+            },
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Shirt"
+        },
+        "samples.Outfit.Shirt.ShirtType": {
+            "enum": [
+                "T_SHIRT",
+                "LONG_SLEEVE",
+                "NO_SHIRT"
+            ],
+            "enumValues": [
+                0,
+                1,
+                2
+            ],
+            "type": "string",
+            "title": "Shirt Type"
+        }
+    }
+}`

--- a/internal/converter/testdata/proto/NestedUnreferencedEnum.proto
+++ b/internal/converter/testdata/proto/NestedUnreferencedEnum.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+package samples;
+import "options.proto";
+
+// A set of predefined gear ratios and torque maps.
+message Outfit {
+  message Shirt {
+    enum ShirtType {
+      option (protoc.gen.jsonschema.enum_options).enums_as_strings_only = true;
+      T_SHIRT = 0;
+      LONG_SLEEVE = 1;
+      NO_SHIRT = 2;
+    }
+    oneof shirt {
+      // When shirt_type is unset, no shirt is selected.
+      ShirtType shirt_type = 1;
+    }
+  }
+  message Pants {
+    enum PantsType {
+      option (protoc.gen.jsonschema.enum_options).enums_as_strings_only = true;
+      SHORTS = 0;
+      LONG_PANTS = 1;
+    }
+    oneof pants {
+      // When pants_type is unset, no pants are selected. Not recommended.
+      PantsType pants_type = 1;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Previously we were only searching references messages for enums, now we also search unreferenced messages for enums as well.
Also, `enumValues` was not removed from the schema for referenced enums.

## Testing
Added a more comprehensive test case.
Also pulled into applied2 and tested