### PR TITLE
[API] Set well known types in new field

### DIFF
--- a/internal/converter/jsonschema/reflect.go
+++ b/internal/converter/jsonschema/reflect.go
@@ -92,6 +92,7 @@ type Type struct {
 	IgnoreInAutocomplete bool                   `json:"ignoreInAutocomplete,omitempty"` // custom
 	Units                protos.NumericalUnits  `json:"units,omitempty"`                // custom
 	OneofName            string                 `json:"oneofName,omitempty"`            // custom
+	WellKnownType        string                 `json:"wellKnownTypes,omitempty"`       // custom
 	Not                  *Type                  `json:"not,omitempty"`                  // section 5.25
 	Definitions          Definitions            `json:"definitions,omitempty"`          // section 5.26
 	// RFC draft-wright-json-schema-validation-00, section 6, 7

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -26,7 +26,8 @@ const GoogleValue = `{
                         }
                     ],
                     "title": "Value",
-                    "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
+                    "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value.",
+                    "format": "value"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/testdata/google_value.go
+++ b/internal/converter/testdata/google_value.go
@@ -25,9 +25,41 @@ const GoogleValue = `{
                             "type": "string"
                         }
                     ],
+                    "wellKnownTypes": "Value",
                     "title": "Value",
-                    "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value.",
-                    "format": "value"
+                    "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
+                },
+                "args": {
+                    "properties": {
+                        "values": {
+                            "items": {
+                                "oneOf": [
+                                    {
+                                        "type": "array"
+                                    },
+                                    {
+                                        "type": "boolean"
+                                    },
+                                    {
+                                        "type": "number"
+                                    },
+                                    {
+                                        "type": "object"
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ],
+                                "wellKnownTypes": "Value",
+                                "title": "Value",
+                                "description": "` + "`Value`" + ` represents a dynamically typed value which can be either null, a number, a string, a boolean, a recursive struct value, or a list of values. A producer of value is expected to set one of these variants. Absence of any variant indicates an error. The JSON representation for ` + "`Value`" + ` is JSON value."
+                            },
+                            "type": "array",
+                            "description": "Repeated field of dynamically typed values."
+                        }
+                    },
+                    "additionalProperties": true,
+                    "type": "object"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/testdata/proto/GoogleValue.proto
+++ b/internal/converter/testdata/proto/GoogleValue.proto
@@ -5,4 +5,5 @@ import "google/protobuf/struct.proto";
 
 message GoogleValue {
   google.protobuf.Value arg = 1;
+  google.protobuf.ListValue args = 2;
 }

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -705,15 +705,16 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 				{Type: gojsonschema.TYPE_OBJECT},
 				{Type: gojsonschema.TYPE_STRING},
 			}
-			jsonSchemaType.Format = "value"
+			jsonSchemaType.WellKnownType = "Value"
 		case "Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
+			jsonSchemaType.WellKnownType = "Duration"
 		case "Empty":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
-			jsonSchemaType.Format = "empty"
+			jsonSchemaType.WellKnownType = "Empty"
 		case "Struct":
 			jsonSchemaType.Type = gojsonschema.TYPE_OBJECT
-			jsonSchemaType.Format = "struct"
+			jsonSchemaType.WellKnownType = "Struct"
 		}
 
 		// If we're allowing nulls then prepare a OneOf:

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -705,6 +705,7 @@ func (c *Converter) recursiveConvertMessageType(curPkg *ProtoPackage, msgDesc *d
 				{Type: gojsonschema.TYPE_OBJECT},
 				{Type: gojsonschema.TYPE_STRING},
 			}
+			jsonSchemaType.Format = "value"
 		case "Duration":
 			jsonSchemaType.Type = gojsonschema.TYPE_STRING
 		case "Empty":


### PR DESCRIPTION
Previoiusly we were doing a combination of using the `format` field or just pattern detecting. About time we just went this route and could easily deterministically tell what "well known type" something is.