### PR TITLE
Populate comments on enums

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -207,16 +207,21 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 	// If we need to trim prefix from enum value
 	enumNamePrefix := fmt.Sprintf("%s_", strcase.ToScreamingSnake(*enum.Name))
 
+	enumDescriptionMap := make(map[string]string)
+
 	// We have found an enum, append its values:
 	for _, value := range enum.Value {
+
+		valueName := value.GetName()
 
 		// Each ENUM value can have comments too:
 		var valueDescription string
 		if src := c.sourceInfo.GetEnumValue(value); src != nil {
 			_, valueDescription = c.formatTitleAndDescription(nil, src)
+			if valueDescription != "" {
+				enumDescriptionMap[valueName] = valueDescription
+			}
 		}
-
-		valueName := value.GetName()
 
 		// If enum name prefix should be removed from enum value name:
 		if converterFlags.EnumsTrimPrefix {
@@ -239,6 +244,10 @@ func (c *Converter) convertEnumType(enum *descriptor.EnumDescriptorProto, conver
 		} else {
 			jsonSchemaType.Enum = append(jsonSchemaType.Enum, value.Number)
 		}
+	}
+
+	if !converterFlags.EnumsAsConstants && len(enumDescriptionMap) != 0 {
+		jsonSchemaType.EnumDescription = enumDescriptionMap
 	}
 
 	return jsonSchemaType, nil

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -468,7 +468,7 @@ func configureSampleProtos() map[string]sampleProto {
 			ObjectsToValidatePass: []string{testdata.SelfReferencePass},
 		},
 		"SeveralEnums": {
-			ExpectedJSONSchema:    []string{testdata.FirstEnum, testdata.SecondEnum},
+			ExpectedJSONSchema:    []string{testdata.FirstEnum, testdata.SecondEnum, testdata.EnumWithComments},
 			FilesToGenerate:       []string{"SeveralEnums.proto"},
 			ProtoFileName:         "SeveralEnums.proto",
 			ObjectsToValidateFail: []string{testdata.FirstEnumFail, testdata.SecondEnumFail},

--- a/internal/converter/jsonschema/reflect.go
+++ b/internal/converter/jsonschema/reflect.go
@@ -94,6 +94,7 @@ type Type struct {
 	OneofName            string                 `json:"oneofName,omitempty"`            // custom
 	Not                  *Type                  `json:"not,omitempty"`                  // section 5.25
 	Definitions          Definitions            `json:"definitions,omitempty"`          // section 5.26
+	EnumDescription      map[string]string      `json:"enumDescription,omitempty"`      // custom
 	// RFC draft-wright-json-schema-validation-00, section 6, 7
 	Title       string        `json:"title,omitempty"`       // section 6.1
 	Description string        `json:"description,omitempty"` // section 6.1

--- a/internal/converter/testdata/enum_with_comments.go
+++ b/internal/converter/testdata/enum_with_comments.go
@@ -1,0 +1,29 @@
+package testdata
+
+const EnumWithComments = `{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$fullRef": "#/definitions/samples.EnumWithComments",
+    "enum": [
+        "VAL1",
+        0,
+        "VAL2",
+        1,
+        "VAL3",
+        2
+    ],
+    "oneOf": [
+        {
+            "type": "string"
+        },
+        {
+            "type": "integer"
+        }
+    ],
+    "enumDescription": {
+        "VAL1": "This description discusses value number 1. Not much to say about value 1.",
+        "VAL2": "Value 2 comes after value1. It's not as important.",
+        "VAL3": "Value 3 is the most important. Here is a multiline description about the third value. Done talking about value 3 now."
+    },
+    "title": "Enum With Comments",
+    "description": "This enum contains a lot of information."
+}`

--- a/internal/converter/testdata/proto/SeveralEnums.proto
+++ b/internal/converter/testdata/proto/SeveralEnums.proto
@@ -14,3 +14,17 @@ enum SecondEnum {
     VALUE_6 = 2;
     VALUE_7 = 3;
 }
+
+
+// This enum contains a lot of information.
+enum EnumWithComments {
+    // This description discusses value number 1.
+    // Not much to say about value 1.
+    VAL1 = 0;
+    // Value 2 comes after value1. It's not as important.
+    VAL2 = 1;
+    // Value 3 is the most important.
+    // Here is a multiline description about the third value.
+    // Done talking about value 3 now.
+    VAL3 = 2;
+}


### PR DESCRIPTION
Add new field in json that contains a map from enum value name to comment (if it exists).
Note that I tried using the existing option of `enums_as_constants` (we use `enums_as_strings`) to populate the enum comments but it didn't work when pulled into applied2 ☹️ . (Also the switch would be backwards incompatible)