### PR TITLE
[API] For int64, set `format` to `int64`

### DIFF
--- a/internal/converter/testdata/array_of_primitives.go
+++ b/internal/converter/testdata/array_of_primitives.go
@@ -41,7 +41,8 @@ const ArrayOfPrimitives = `{
                     "items": {
                         "oneOf": [
                             {
-                                "type": "string"
+                                "type": "integer",
+                                "format": "int64"
                             },
                             {
                                 "type": "null"
@@ -80,7 +81,8 @@ const ArrayOfPrimitives = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64"
                         },
                         {
                             "type": "null"
@@ -147,7 +149,8 @@ const ArrayOfPrimitivesDouble = `{
                     "items": {
                         "oneOf": [
                             {
-                                "type": "string"
+                                "type": "integer",
+                                "format": "int64"
                             },
                             {
                                 "type": "null"
@@ -186,7 +189,8 @@ const ArrayOfPrimitivesDouble = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64"
                         },
                         {
                             "type": "null"
@@ -196,7 +200,8 @@ const ArrayOfPrimitivesDouble = `{
                 "bigNumber": {
                     "oneOf": [
                         {
-                            "type": "string"
+                            "type": "integer",
+                            "format": "int64"
                         },
                         {
                             "type": "null"

--- a/internal/converter/testdata/array_of_primitives.go
+++ b/internal/converter/testdata/array_of_primitives.go
@@ -41,7 +41,7 @@ const ArrayOfPrimitives = `{
                     "items": {
                         "oneOf": [
                             {
-                                "type": "integer",
+                                "type": "string",
                                 "format": "int64"
                             },
                             {
@@ -81,7 +81,7 @@ const ArrayOfPrimitives = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "integer",
+                            "type": "string",
                             "format": "int64"
                         },
                         {
@@ -149,7 +149,7 @@ const ArrayOfPrimitivesDouble = `{
                     "items": {
                         "oneOf": [
                             {
-                                "type": "integer",
+                                "type": "string",
                                 "format": "int64"
                             },
                             {
@@ -189,7 +189,7 @@ const ArrayOfPrimitivesDouble = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "integer",
+                            "type": "string",
                             "format": "int64"
                         },
                         {
@@ -200,7 +200,7 @@ const ArrayOfPrimitivesDouble = `{
                 "bigNumber": {
                     "oneOf": [
                         {
-                            "type": "integer",
+                            "type": "string",
                             "format": "int64"
                         },
                         {

--- a/internal/converter/testdata/bigint_as_string.go
+++ b/internal/converter/testdata/bigint_as_string.go
@@ -10,7 +10,8 @@ const BigIntAsString = `{
                 "big_number": {
                     "oneOf": [
                         {
-                            "type": "integer"
+                            "type": "integer",
+                            "format": "int64"
                         },
                         {
                             "type": "null"

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -26,7 +26,8 @@ const JSONFields = `{
                     "type": "boolean"
                 },
                 "snakeNumb": {
-                    "type": "string"
+                    "type": "integer",
+                    "format": "int64"
                 },
                 "otherNumb": {
                     "type": "integer"

--- a/internal/converter/testdata/json_fields.go
+++ b/internal/converter/testdata/json_fields.go
@@ -26,7 +26,7 @@ const JSONFields = `{
                     "type": "boolean"
                 },
                 "snakeNumb": {
-                    "type": "integer",
+                    "type": "string",
                     "format": "int64"
                 },
                 "otherNumb": {

--- a/internal/converter/testdata/message_kind_12.go
+++ b/internal/converter/testdata/message_kind_12.go
@@ -233,7 +233,8 @@ const MessageKind12 = `{
                     "type": "boolean"
                 },
                 "baz": {
-                    "type": "string"
+                    "type": "integer",
+                    "format": "int64"
                 }
             },
             "additionalProperties": true,

--- a/internal/converter/testdata/message_kind_12.go
+++ b/internal/converter/testdata/message_kind_12.go
@@ -233,7 +233,7 @@ const MessageKind12 = `{
                     "type": "boolean"
                 },
                 "baz": {
-                    "type": "integer",
+                    "type": "string",
                     "format": "int64"
                 }
             },

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -158,14 +158,30 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
 
-		if messageFlags.AllowNullValues {
-			jsonSchemaType.OneOf = []*jsonschema.Type{
-				{Type: gojsonschema.TYPE_INTEGER, Format: "int64"},
-				{Type: gojsonschema.TYPE_NULL},
+		// As integer:
+		if c.Flags.DisallowBigIntsAsStrings {
+			if messageFlags.AllowNullValues {
+				jsonSchemaType.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_INTEGER, Format: "int64"},
+					{Type: gojsonschema.TYPE_NULL},
+				}
+			} else {
+				jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
+				jsonSchemaType.Format = "int64"
 			}
-		} else {
-			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
-			jsonSchemaType.Format = "int64"
+		}
+
+		// As string:
+		if !c.Flags.DisallowBigIntsAsStrings {
+			if messageFlags.AllowNullValues {
+				jsonSchemaType.OneOf = []*jsonschema.Type{
+					{Type: gojsonschema.TYPE_STRING, Format: "int64"},
+					{Type: gojsonschema.TYPE_NULL},
+				}
+			} else {
+				jsonSchemaType.Type = gojsonschema.TYPE_STRING
+				jsonSchemaType.Format = "int64"
+			}
 		}
 
 	// String:

--- a/internal/converter/types.go
+++ b/internal/converter/types.go
@@ -158,28 +158,14 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 		descriptor.FieldDescriptorProto_TYPE_SFIXED64,
 		descriptor.FieldDescriptorProto_TYPE_SINT64:
 
-		// As integer:
-		if c.Flags.DisallowBigIntsAsStrings {
-			if messageFlags.AllowNullValues {
-				jsonSchemaType.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_INTEGER},
-					{Type: gojsonschema.TYPE_NULL},
-				}
-			} else {
-				jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
+		if messageFlags.AllowNullValues {
+			jsonSchemaType.OneOf = []*jsonschema.Type{
+				{Type: gojsonschema.TYPE_INTEGER, Format: "int64"},
+				{Type: gojsonschema.TYPE_NULL},
 			}
-		}
-
-		// As string:
-		if !c.Flags.DisallowBigIntsAsStrings {
-			if messageFlags.AllowNullValues {
-				jsonSchemaType.OneOf = []*jsonschema.Type{
-					{Type: gojsonschema.TYPE_STRING},
-					{Type: gojsonschema.TYPE_NULL},
-				}
-			} else {
-				jsonSchemaType.Type = gojsonschema.TYPE_STRING
-			}
+		} else {
+			jsonSchemaType.Type = gojsonschema.TYPE_INTEGER
+			jsonSchemaType.Format = "int64"
 		}
 
 	// String:
@@ -348,7 +334,7 @@ func (c *Converter) convertField(curPkg *ProtoPackage, desc *descriptor.FieldDes
 	}
 
 	// Recurse nested objects / arrays of objects (if necessary):
-	if jsonSchemaType.Type == gojsonschema.TYPE_OBJECT {
+	if jsonSchemaType.Type == gojsonschema.TYPE_OBJECT && jsonSchemaType.Format != "int64" {
 
 		recordType, pkgName, ok := c.lookupType(curPkg, desc.GetTypeName())
 		if !ok {


### PR DESCRIPTION
When we have type int64, set the `format` to be `int64`. In our docs generation, if we detect this, we will display: "int64" for protobuf based docs or "string" for REST API docs.
Slack thread with context [here](https://appliedint.slack.com/archives/C06682BEBCY/p1713315918986049)